### PR TITLE
Fix deprecation of Pillow ImageDraw textsize()

### DIFF
--- a/devdeck_core/deck_context.py
+++ b/devdeck_core/deck_context.py
@@ -52,8 +52,8 @@ class DeckContext:
 
         image = Image.new("RGB", (512, 512))
         draw = ImageDraw.Draw(image)
-        label_w, label_h = draw.textsize('%s' % text, font=font)
-        label_pos = ((512 - label_w) // 2, (512 - label_h) // 2)
+        left, top, right, bottom = draw.textbbox((0, 0), '%s' % text, font=font)
+        label_pos = ((512 - (right - left)) // 2, (512 - (bottom - top)) // 2)
         draw.text(label_pos, text=text, font=font, fill=fill)
         self.set_key_image_native(key_no, image)
 

--- a/devdeck_core/rendering/badge_count_renderer.py
+++ b/devdeck_core/rendering/badge_count_renderer.py
@@ -21,7 +21,7 @@ class BadgeCountRenderer:
         font = ImageFont.truetype(self.font_filename, self._font_size)
 
         draw = ImageDraw.Draw(self.renderer.img)
-        label_w, label_h = draw.textsize('%s' % self.text, font=font, stroke_width=4)
+        left, top, right, bottom = draw.textbbox((0, 0), '%s' % self.text, font=font, stroke_width=4)
 
         # Circle
 
@@ -31,8 +31,8 @@ class BadgeCountRenderer:
                       self.renderer.img.height - self.corner_offset), fill='red')
 
         # Label
-        label_pos = (self.renderer.img.width - (self.circle_size / 2) - self.corner_offset - (label_w / 2),
-                     self.renderer.img.height - (self.circle_size / 2) - self.corner_offset - (label_h / 2))
+        label_pos = (self.renderer.img.width - (self.circle_size / 2) - self.corner_offset - ((right - left) / 2),
+                     self.renderer.img.height - (self.circle_size / 2) - self.corner_offset - ((bottom - top) / 2))
         draw.text(label_pos, text=self.text, font=font, fill=self.fill, stroke_width=4)
 
         return self.renderer

--- a/devdeck_core/rendering/text_renderer.py
+++ b/devdeck_core/rendering/text_renderer.py
@@ -48,14 +48,14 @@ class TextRenderer:
         font = ImageFont.truetype(self.font_filename, self._font_size)
 
         draw = ImageDraw.Draw(self.renderer.img)
-        label_w, label_h = draw.textsize('%s' % self.text, font=font)
+        left, top, right, bottom = draw.textbbox((0, 0), '%s' % self.text, font=font)
 
         # Positioning
         label_pos = (self._x, self._y)
         if self.center_vertical is not None:
-            label_pos = (label_pos[0], ((self.renderer.img.height - label_h) // 2) + self.center_vertical)
+            label_pos = (label_pos[0], ((self.renderer.img.height - (bottom - top)) // 2) + self.center_vertical)
         if self.center_horizontal is not None:
-            label_pos = (((self.renderer.img.width - label_w) // 2) + self.center_horizontal, label_pos[1])
+            label_pos = (((self.renderer.img.width - (right - left)) // 2) + self.center_horizontal, label_pos[1])
 
         draw.text(label_pos, text=self.text, font=font, fill=self.fill, align=self.align)
 


### PR DESCRIPTION
Pillow has marked ImageDraw.textsize() as deprecated[1] for removal in version 10. Use the new recommended method for getting the text height and width.

[1] https://pillow.readthedocs.io/en/stable/deprecations.html#font-size-and-offset-methods